### PR TITLE
Made the stringify lib wrap JSON.stringify

### DIFF
--- a/cedar.js
+++ b/cedar.js
@@ -1,3 +1,5 @@
+require('./lib/common/stringify');
+
 /**
  * Create and return a logger with one or more transports.
  */

--- a/lib/common/stringify.js
+++ b/lib/common/stringify.js
@@ -1,34 +1,20 @@
-var stringify = module.exports = function (obj, decycle, space) {
-  return JSON.stringify(obj, getSerialize(decycle), space);
-};
-
-function getSerialize(decycle) {
-  var seen = [], keys = [];
-  decycle = decycle || function(key, value) {
-    return '[Circular ' + getPath(value, seen, keys) + ']';
-  };
-  return function(key, value) {
-    var ret = value;
-    if (typeof value === 'object' && value) {
-      if (seen.indexOf(value) !== -1)
-        ret = decycle(key, value);
-      else {
-        seen.push(value);
-        keys.push(key);
+/**
+ * Wrap the native JSON.stringify with something Circular-safe.
+ */
+var stringify = JSON.stringify;
+var isWrapped = stringify.toString().indexOf('[native code]') < 0;
+JSON.stringify = isWrapped ? stringify : function (o, u, w) {
+  var a = [];
+  return stringify(o, u || function(k, v) {
+    if (typeof v == 'object' && v) {
+      var l = a.length;
+      for (var i = 0; i < l; i++) {
+        if (a[i] == v) {
+          return "[Circular " + (l - i) + "]";
+        }
       }
+      a.push(v);
     }
-    return ret;
-  };
-}
-
-function getPath(value, seen, keys) {
-  var index = seen.indexOf(value);
-  var path = [ keys[index] ];
-  for (index--; index >= 0; index--) {
-    if (seen[index][ path[0] ] === value) {
-      value = seen[index];
-      path.unshift(keys[index]);
-    }
-  }
-  return '~' + path.join('.');
-}
+    return v;
+  }, w);
+};

--- a/lib/transports/base.js
+++ b/lib/transports/base.js
@@ -72,8 +72,8 @@ Base.defaults = {
   // Don't add any space to JSON.
   space: '',
 
-  // Use a stringify method that accounts for circular references.
-  stringify: require('../common/stringify'),
+  // Stringify with `JSON.stringify`.
+  stringify: JSON.stringify,
 
   // Join arguments together as an array.
   join: function (args) {
@@ -84,7 +84,7 @@ Base.defaults = {
         arg = '"' + (arg.stack || arg.toString()).replace(/\n/, '\\n') + '"';
       }
       else {
-        arg = this.stringify(arg, null, this.space);
+        arg = JSON.stringify(arg, null, this.space);
       }
       list.push(arg);
     }

--- a/lib/transports/multi.js
+++ b/lib/transports/multi.js
@@ -10,7 +10,7 @@ var Base = require('./base');
 var Multi = module.exports = function (loggers) {
 
   // Give the logger an ID based on its configuration, and register it.
-  var json = stringify(loggers);
+  var json = JSON.stringify(loggers);
   var hash = crypto.createHash('md5').update(json).digest('hex');
   var id = 'CEDAR_' + hash.substr(0, 8);
 

--- a/package.json
+++ b/package.json
@@ -1,10 +1,10 @@
 {
   "name": "cedar",
-  "version": "0.1.0",
-  "description": "User-friendly logging",
+  "version": "0.1.1",
+  "description": "User-friendly logger",
   "dependencies": {},
   "devDependencies": {
-    "exam": "^0.1.3",
+    "exam": "^0.1.4",
     "zeriousify": "^0.1.10",
     "istanbul": "0.2.11",
     "coveralls": "2.10.0"


### PR DESCRIPTION
The native JSON.stringify is not circular-safe. There are 3 possible solutions for dealing with this:
- Use something else (like a wrapper) in each place where you want to stringify.
- Pass a `replacer` as the 2nd argument each time JSON.stringify is called.
- Wrap JSON.stringify with a function that calls JSON.stringify with a default replacer if none is provided.

I've decided to go with option 3, and all libraries that use Cedar (such as Lighter) will benefit from the wrapper.
