### PR TITLE
Fixed whitespace

### DIFF
--- a/lib/transports/console.js
+++ b/lib/transports/console.js
@@ -178,7 +178,7 @@ Console.defaults = Base.decorate({
           line = this.stringify(line, null, space);
         }
       }
-      lines.push(line.replace(/\n/g, '\n' + space));
+      lines.push(line);
     }
 
     // Restore stderr and stdout.

--- a/lib/transports/file.js
+++ b/lib/transports/file.js
@@ -50,7 +50,7 @@ File.defaults = Base.decorate({
 
   // Write a timestamped message.
   format: function (message, type, prefix) {
-    return prefix + timestamp() + ' ' + message + '\n';
+    return prefix + timestamp() + ' ' + message.replace(/\n/g, '\\n') + '\n';
   },
 
   // A start time in the past will trigger a new file.


### PR DESCRIPTION
This change ensures that console logs are not overly indented, and that file logs stay on one line.
